### PR TITLE
[FEATURE] delve for remote debugging added

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -3,7 +3,7 @@ disable_snapshots()
 allow_k8s_contexts(os.getenv("TILT_ALLOW_CONTEXT"))
 
 k8s_yaml('deployment/kubernetes.yaml')
-k8s_resource('dind', port_forwards=['2375', '12375'])
+k8s_resource('dind', port_forwards=['2375', '12375', '40000'])
 
 target='prod'
 live_update=[]
@@ -14,7 +14,7 @@ if os.environ.get('PROD', '') ==  '':
     sync('go.sum', '/app/go.sum'),
     sync('pkg',    '/app/pkg'),
     sync('main.go', '/app/main.go'),
-    run('go install .'),
+    run('go install -gcflags=\"all=-N -l\" .'),
   ]
 
 docker_build(

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -4,8 +4,9 @@ FROM golang:1.17.3-alpine@sha256:55da409cc0fe11df63a7d6962fbefd1321fedc305d9969d
 WORKDIR /app
 
 # entrypoint
-RUN apk add --no-cache entr docker
+RUN apk add --no-cache entr docker build-base
 COPY ./deployment/entrypoint.sh /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]
 
 # dependencies
@@ -16,7 +17,11 @@ RUN go mod download
 # server
 COPY main.go .
 COPY pkg ./pkg
-RUN go install .
+
+RUN if [[ "$DEBUG" = "true" ]] ; then go install -gcflags "all=-N -l" . ; else go install . ; fi
+
+#remote debuging
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 # production image ############################################
 FROM alpine:3.15.0@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300 AS prod

--- a/deployment/entrypoint.sh
+++ b/deployment/entrypoint.sh
@@ -1,2 +1,7 @@
 #!/bin/sh
-echo `which dind-nurse` | entr -nr `which dind-nurse` $@
+
+if [ "$DEBUG" = "true" ]; then
+  echo `which dind-nurse` | dlv --listen=:$DEBUG_PORT --headless=true --api-version=2 --accept-multiclient exec `which dind-nurse` $@
+else
+  echo `which dind-nurse` | entr -nr `which dind-nurse` $@
+fi


### PR DESCRIPTION
This pull request adds [delve](https://github.com/go-delve/delve) to the setup. With delve you have the possibility to debug the project remotely with the tools of your choice.

For this the following environment variables must be set
```
DEBUG=TRUE
DEBUG_PORT=40000
```